### PR TITLE
Ond233 258 add control stream endpoint

### DIFF
--- a/ondewo/csi/conversation.proto
+++ b/ondewo/csi/conversation.proto
@@ -45,6 +45,8 @@ service Conversations {
     // Check the health of S2T, NLU and T2S servers
     rpc CheckUpstreamHealth(google.protobuf.Empty) returns (CheckUpstreamHealthResponse) {
     };
+    rpc GetControlStream (ControlStreamRequest) returns (stream ControlStreamResponse) {
+    };
 
 }
 
@@ -154,4 +156,14 @@ message CheckUpstreamHealthResponse {
     google.rpc.Status s2t_status = 1;
     google.rpc.Status nlu_status = 2;
     google.rpc.Status t2s_status = 3;
+}
+
+message ControlStreamRequest{}
+
+message ControlStreamResponse{
+    enum ControlStatus {
+        NORMAL_STREAM = 0;
+        EMERGENCY_STOP = 1;
+    }
+    ControlStatus control_status = 1;
 }

--- a/ondewo/csi/conversation.proto
+++ b/ondewo/csi/conversation.proto
@@ -162,7 +162,7 @@ message CheckUpstreamHealthResponse {
 message ControlStreamRequest{}
 
 enum ControlStatus {
-        NORMAL_STREAM = 0;
+        OK = 0;
         EMERGENCY_STOP = 1;
 }
 

--- a/ondewo/csi/conversation.proto
+++ b/ondewo/csi/conversation.proto
@@ -47,7 +47,8 @@ service Conversations {
     };
     rpc GetControlStream (ControlStreamRequest) returns (stream ControlStreamResponse) {
     };
-
+    rpc SetControlStatus (SetControlStatusRequest) returns (SetControlStatusResponse) {
+    };
 }
 
 // The top-level message sent by client to `CreateS2sPipeline` and `UpdateS2sPipeline` endpoints and received from
@@ -160,10 +161,20 @@ message CheckUpstreamHealthResponse {
 
 message ControlStreamRequest{}
 
-message ControlStreamResponse{
-    enum ControlStatus {
+enum ControlStatus {
         NORMAL_STREAM = 0;
         EMERGENCY_STOP = 1;
-    }
+}
+
+message ControlStreamResponse{
     ControlStatus control_status = 1;
+}
+
+message SetControlStatusRequest{
+    ControlStatus control_status = 1;
+}
+
+message SetControlStatusResponse{
+    ControlStatus old_control_status = 1;
+    ControlStatus new_control_status = 2;
 }


### PR DESCRIPTION
This PR adds 2 endpoints and corresponding proto messages for requests and responses:

1. streaming endpoint control status stream
2. set control status