### PR TITLE
Improve Proto Documentation Build and HTML Comment Rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,30 @@ help: ## Print usage info about help targets
 makefile_chapters: ## Shows all sections of Makefile
 	@echo `cat Makefile| grep "########################################################" -A 1 | grep -v "########################################################"`
 
+build_docs: ## Build documentation locally using the same Docker image as CI/CD
+	@echo "Building documentation using ondewo-protoc-gen-doc-action..."
+	@if [ ! -d ".tmp-protoc-gen-doc-action" ]; then \
+		echo "Cloning ondewo-protoc-gen-doc-action..."; \
+		git clone --depth 1 https://github.com/ondewo/ondewo-protoc-gen-doc-action.git .tmp-protoc-gen-doc-action; \
+	fi
+	@echo "Building Docker image with ONDEWO templates..."
+	@docker build -t ondewo-protoc-gen-doc:local .tmp-protoc-gen-doc-action
+	@echo "Generating documentation..."
+	@docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		-v "$(shell pwd):/workspace" \
+		-w /workspace \
+		ondewo-protoc-gen-doc:local \
+		html,md index
+	@echo "✓ Documentation generated in docs/ directory"
+	@echo "  Open docs/index.html in your browser to view"
+
+clean_docs_builder: ## Remove the cloned protoc-gen-doc-action repo and Docker image
+	@echo "Cleaning up documentation builder..."
+	@rm -rf .tmp-protoc-gen-doc-action
+	@docker rmi ondewo-protoc-gen-doc:local 2>/dev/null || true
+	@echo "✓ Cleanup complete"
+
 TEST:
 	@echo "----------------------------------------------\nGITHUB_GH_TOKEN\n----------------------------------------------\n${GITHUB_GH_TOKEN}\n"
 	@echo "----------------------------------------------\nCURRENT_RELEASE_NOTES\n----------------------------------------------\n${CURRENT_RELEASE_NOTES}\n"

--- a/docs/index.html
+++ b/docs/index.html
@@ -4095,7 +4095,7 @@ All upstreams unhealthy:
                   <td>audio</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Optional. The input audio content to be recognized. </p></td>
                 </tr>
               
                 <tr>
@@ -4226,7 +4226,7 @@ All upstreams unhealthy:
                   <td>type</td>
                   <td><a href="#ondewo.csi.SipTrigger.SipTriggerType">SipTrigger.SipTriggerType</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Type of the SIP trigger. </p></td>
                 </tr>
               
                 <tr>
@@ -4875,7 +4875,7 @@ All upstreams unhealthy:
         </table>
       
         <h3 id="ondewo.csi.SipTrigger.SipTriggerType" class="title-badge enum">SipTrigger.SipTriggerType</h3>
-        <p>type of the SIP trigger</p>
+        <p>Type of SIP trigger that can be executed during a conversation.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3578,7 +3578,7 @@
       
         
         <h3 id="ondewo.csi.Conversations" class="title-badge service">Conversations</h3>
-        <p>endpoints of csi service</p>
+        <p><p>Endpoints of CSI service.</p></p>
 
         
         <div id="ondewo.csi.Conversations-methods" class="service-methods">Service Methods</div>
@@ -3587,7 +3587,7 @@
 
           <pre>rpc CreateS2sPipeline (<a href="#ondewo.csi.S2sPipeline">S2sPipeline</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.
+          <p>Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.</p>
 
 <p>Examples:</p>
 
@@ -3606,7 +3606,7 @@ grpcurl -plaintext -d '{
 
           <pre>rpc GetS2sPipeline (<a href="#ondewo.csi.S2sPipelineId">S2sPipelineId</a>) returns (<a href="#ondewo.csi.S2sPipeline">S2sPipeline)</a></pre>
 
-          Retrieve the S2S pipeline with the ID specified in the request message.
+          <p>Retrieve the S2S pipeline with the ID specified in the request message.</p>
 
 <p>Examples:</p>
 
@@ -3626,7 +3626,7 @@ grpcurl -plaintext -d '{"id": "pizza"}' localhost:50051 ondewo.csi.Conversations
 
           <pre>rpc UpdateS2sPipeline (<a href="#ondewo.csi.S2sPipeline">S2sPipeline</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          Update the S2S pipeline specified in the request message. The pipeline must exist.
+          <p>Update the S2S pipeline specified in the request message. The pipeline must exist.</p>
 
 <p>Examples:</p>
 
@@ -3645,7 +3645,7 @@ grpcurl -plaintext -d '{
 
           <pre>rpc DeleteS2sPipeline (<a href="#ondewo.csi.S2sPipelineId">S2sPipelineId</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.
+          <p>Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.</p>
 
 <p>Examples:</p>
 
@@ -3658,7 +3658,7 @@ grpcurl -plaintext -d '{"id": "pizza"}' localhost:50051 ondewo.csi.Conversations
 
           <pre>rpc ListS2sPipelines (<a href="#ondewo.csi.ListS2sPipelinesRequest">ListS2sPipelinesRequest</a>) returns (<a href="#ondewo.csi.ListS2sPipelinesResponse">ListS2sPipelinesResponse)</a></pre>
 
-          List all S2S pipelines of the server.
+          <p>List all S2S pipelines of the server.</p>
 
 <p>Examples:</p>
 
@@ -3681,14 +3681,13 @@ grpcurl -plaintext localhost:50051 ondewo.csi.Conversations.ListS2sPipelines
 
           <pre>rpc S2sStream (stream <a href="#ondewo.csi.S2sStreamRequest">S2sStreamRequest</a>) returns (stream <a href="#ondewo.csi.S2sStreamResponse">S2sStreamResponse)</a></pre>
 
-          Processes a natural language query in audio format in a streaming fashion
-and returns structured, actionable data as a result.
+          <p>Processes a natural language query in audio format in a streaming fashion and returns structured, actionable data as a result.</p>
         
           <h4 id="ondewo.csi.Conversations.CheckUpstreamHealth" class="title-badge method">CheckUpstreamHealth</h4>
 
           <pre>rpc CheckUpstreamHealth (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.csi.CheckUpstreamHealthResponse">CheckUpstreamHealthResponse)</a></pre>
 
-          Check the health of S2T, NLU and T2S servers
+          <p>Check the health of S2T, NLU and T2S servers.</p>
 
 <p>Examples:</p>
 
@@ -3719,13 +3718,13 @@ All upstreams unhealthy:
 
           <pre>rpc GetControlStream (<a href="#ondewo.csi.ControlStreamRequest">ControlStreamRequest</a>) returns (stream <a href="#ondewo.csi.ControlStreamResponse">ControlStreamResponse)</a></pre>
 
-          Get the control stream to control sip, t2s, s2t etc. during a conversation
+          <p>Get the control stream to control sip, t2s, s2t etc. during a conversation.</p>
         
           <h4 id="ondewo.csi.Conversations.SetControlStatus" class="title-badge method">SetControlStatus</h4>
 
           <pre>rpc SetControlStatus (<a href="#ondewo.csi.SetControlStatusRequest">SetControlStatusRequest</a>) returns (<a href="#ondewo.csi.SetControlStatusResponse">SetControlStatusResponse)</a></pre>
 
-          Send a message on the control stream to control sip, t2s, s2t etc. during a conversation
+          <p>Send a message on the control stream to control sip, t2s, s2t etc. during a conversation.</p>
         
 
         
@@ -3737,7 +3736,7 @@ All upstreams unhealthy:
       <div id="ondewo/csi/conversation.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.csi.CheckUpstreamHealthResponse" class="title-badge message">CheckUpstreamHealthResponse</h3>
-        <p>Health checks</p>
+        <p>Health checks.</p>
 
         
           <table class="field-table">
@@ -3775,7 +3774,7 @@ All upstreams unhealthy:
         
       
         <h3 id="ondewo.csi.Condition" class="title-badge message">Condition</h3>
-        <p>A condition message with its type and value</p><p>A Condition can be of various types.</p><p><p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p></p><p><pre><code></p><p>immediate execution</p><p>{</p><p>"type": "immediate"</p><p>}</p><p></code></pre></p><p>number of interactions of the user with the AI agent</p><p><pre><code></p><p>{</p><p>"type": "interactions",</p><p>"value": “10”</p><p>}</p><p></code></pre></p><p>number of seconds</p><p><pre><code></p><p>{</p><p>"type": "duration",</p><p>"value": “3600”</p><p>}</p><p></code></pre></p><p>at a specific date and time</p><p><pre><code></p><p>{</p><p>"type": "datetime",</p><p>"value": "2021-12-23T13:45:00.000Z"</p><p>}</p><p></code></pre></p>
+        <p>A condition message with its type and value.</p><p>A Condition can be of various types.</p><p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p><p>Immediate execution:</p><p><pre><code></p><p>{</p><p>&quot;type&quot;: &quot;immediate&quot;</p><p>}</p><p></code></pre></p><p>Number of interactions of the user with the AI agent:</p><p><pre><code></p><p>{</p><p>&quot;type&quot;: &quot;interactions&quot;,</p><p>&quot;value&quot;: &quot;10&quot;</p><p>}</p><p></code></pre></p><p>Number of seconds:</p><p><pre><code></p><p>{</p><p>&quot;type&quot;: &quot;duration&quot;,</p><p>&quot;value&quot;: &quot;3600&quot;</p><p>}</p><p></code></pre></p><p>At a specific date and time:</p><p><pre><code></p><p>{</p><p>&quot;type&quot;: &quot;datetime&quot;,</p><p>&quot;value&quot;: &quot;2021-12-23T13:45:00.000Z&quot;</p><p>}</p><p></code></pre></p>
 
         
           <table class="field-table">
@@ -3795,8 +3794,7 @@ All upstreams unhealthy:
                   <td>value</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Value of the condition.
-Examples of conditions values based on the condition type are given in the <pre>ConditionType</pre> documentation </p></td>
+                  <td><p>Value of the condition. Examples of conditions values based on the condition type are given in the <code>ConditionType</code> documentation. </p></td>
                 </tr>
               
             </tbody>
@@ -3807,7 +3805,7 @@ Examples of conditions values based on the condition type are given in the <pre>
         
       
         <h3 id="ondewo.csi.ControlMessage" class="title-badge message">ControlMessage</h3>
-        <p>A control message</p><p><p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p></p><p><pre><code></p><p>{</p><p>"service": "<SERVICE_NAME>", 			// e.g. ondewo_s2t</p><p>"method": "<SERVICE_CONTROL_METHOD>", 	// e.g. update_config</p><p>"parameters": [</p><p>// primitive data types and JSON objects are possible</p><p>1,</p><p>1.0,</p><p>-2.0,</p><p>“string”,</p><p>true,</p><p>{</p><p>// parameter JSON object</p><p>},</p><p>{</p><p>// Condition start object</p><p>},</p><p>{</p><p>// Condition end object [optional]</p><p>},</p><p>]</p><p>}</p><p></code></pre></p>
+        <p>A control message.</p><p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p><p><pre><code></p><p>{</p><p>&quot;service&quot;: &quot;&lt;SERVICE_NAME&gt;&quot;, 			// e.g. ondewo_s2t</p><p>&quot;method&quot;: &quot;&lt;SERVICE_CONTROL_METHOD&gt;&quot;, 	// e.g. update_config</p><p>&quot;parameters&quot;: [</p><p>// primitive data types and JSON objects are possible</p><p>1,</p><p>1.0,</p><p>-2.0,</p><p>&quot;string&quot;,</p><p>true,</p><p>{</p><p>// parameter JSON object</p><p>},</p><p>{</p><p>// Condition start object</p><p>},</p><p>{</p><p>// Condition end object [optional]</p><p>},</p><p>]</p><p>}</p><p></code></pre></p>
 
         
           <table class="field-table">
@@ -3820,8 +3818,7 @@ Examples of conditions values based on the condition type are given in the <pre>
                   <td>service</td>
                   <td><a href="#ondewo.csi.ControlMessageServiceName">ControlMessageServiceName</a></td>
                   <td></td>
-                  <td><p>Service to control.
-Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' and 'ondewo_csi' </p></td>
+                  <td><p>Service to control. Valid service names are: <code>ondewo_nlu</code>, <code>ondewo_t2s</code>, <code>ondewo_s2t</code>, <code>ondewo_sip</code> and <code>ondewo_csi</code>. </p></td>
                 </tr>
               
                 <tr>
@@ -3846,7 +3843,7 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.ControlMessageServiceParameters" class="title-badge message">ControlMessageServiceParameters</h3>
-        <p>Parameters of the control message passed to the service specified in the control message</p>
+        <p>Parameters of the control message passed to the service specified in the control message.</p>
 
         
           <table class="field-table">
@@ -3933,14 +3930,14 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.ControlStreamRequest" class="title-badge message">ControlStreamRequest</h3>
-        <p>Control stream message</p>
+        <p>Control stream message.</p>
 
         
 
         
       
         <h3 id="ondewo.csi.ControlStreamResponse" class="title-badge message">ControlStreamResponse</h3>
-        <p>Control stream response message</p>
+        <p>Control stream response message.</p>
 
         
           <table class="field-table">
@@ -3964,14 +3961,14 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.ListS2sPipelinesRequest" class="title-badge message">ListS2sPipelinesRequest</h3>
-        <p>The top-level message sent by client to `ListS2sPipelines` endpoint. Currently without arguments.</p><p>TODO: add filtering options</p>
+        <p>The top-level message sent by client to <code>ListS2sPipelines</code> endpoint. Currently without arguments.</p><p>TODO: add filtering options</p>
 
         
 
         
       
         <h3 id="ondewo.csi.ListS2sPipelinesResponse" class="title-badge message">ListS2sPipelinesResponse</h3>
-        <p>The top-level message received from `ListS2sPipelines` endpoint.</p>
+        <p>The top-level message received from <code>ListS2sPipelines</code> endpoint.</p>
 
         
           <table class="field-table">
@@ -3995,7 +3992,7 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.S2sPipeline" class="title-badge message">S2sPipeline</h3>
-        <p>The top-level message sent by client to `CreateS2sPipeline` and `UpdateS2sPipeline` endpoints and received from</p><p>`GetS2sPipeline` endpoint.</p>
+        <p>The top-level message sent by client to <code>CreateS2sPipeline</code> and <code>UpdateS2sPipeline</code> endpoints and received from <code>GetS2sPipeline</code> endpoint.</p>
 
         
           <table class="field-table">
@@ -4047,7 +4044,7 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.S2sPipelineId" class="title-badge message">S2sPipelineId</h3>
-        <p>The top-level message sent by client to `GetS2sPipeline` and `DeleteS2sPipeline` endpoints.</p>
+        <p>The top-level message sent by client to <code>GetS2sPipeline</code> and <code>DeleteS2sPipeline</code> endpoints.</p>
 
         
           <table class="field-table">
@@ -4071,7 +4068,7 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
         
       
         <h3 id="ondewo.csi.S2sStreamRequest" class="title-badge message">S2sStreamRequest</h3>
-        <p>The top-level message sent by the client to the</p><p>`S2sStream` method.</p><p>Multiple request messages should be sent in order:</p><p>1.  The first message must contain `pipeline_id` and can contain `session_id` or `initial_intent_display_name`.</p><p>The message must not contain `audio` nor `end_of_stream`.</p><p>2.  All subsequent messages must contain `audio`. If `end_of_stream` is `true`, the stream is closed.</p>
+        <p>The top-level message sent by the client to the <code>S2sStream</code> method.</p><p>Multiple request messages should be sent in order:</p><p><ul></p><p><li>The first message must contain <code>pipeline_id</code> and can contain <code>session_id</code> or <code>initial_intent_display_name</code>. The message must not contain <code>audio</code> nor <code>end_of_stream</code>.</li></p><p><li>All subsequent messages must contain <code>audio</code>. If <code>end_of_stream</code> is <code>true</code>, the stream is closed.</li></p><p></ul></p>
 
         
           <table class="field-table">
@@ -4091,24 +4088,21 @@ Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' a
                   <td>session_id</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Optional. The session or call ID specified in the initial request. It’s up to the API caller to choose
-an appropriate string. It can be a random number or some type of user identifier (preferably hashed). </p></td>
+                  <td><p><p>Optional. The session or call ID specified in the initial request. It&apos;s up to the API caller to choose an appropriate string. It can be a random number or some type of user identifier (preferably hashed).</p> </p></td>
                 </tr>
               
                 <tr>
                   <td>audio</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p>If `true`, the recognizer will not return
-any further hypotheses about this piece of the audio. May only be populated
-for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
+                  <td><p> </p></td>
                 </tr>
               
                 <tr>
                   <td>end_of_stream</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>If <code>true</code>, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for <code>event_type</code> = <code>RECOGNITION_EVENT_TRANSCRIPT</code>. </p></td>
                 </tr>
               
                 <tr>
@@ -4126,7 +4120,7 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
         
       
         <h3 id="ondewo.csi.S2sStreamResponse" class="title-badge message">S2sStreamResponse</h3>
-        <p>The top-level message returned from the</p><p>`S2sStream` method.</p><p>A response message is returned for each utterance of the input stream. It contains the full response from NLU system</p><p>in `detect_intent_response` or the full T2S response in `synthesize_response`.</p><p>Multiple response messages can be returned in order:</p><p>1.  The first response message for an input utterance contains response from NLU system `detect_intent_response`</p><p>with detected intent and N fulfillment messages (N >= 0).</p><p>2.  The next N response messages contain for each fulfillment message one of the following:</p><p>a. T2S response `synthesize_response` with synthesized audio</p><p>b. SIP trigger message `sip_trigger` with SIP trigger extracted from the fulfillment message</p>
+        <p>The top-level message returned from the <code>S2sStream</code> method.</p><p>A response message is returned for each utterance of the input stream. It contains the full response from NLU system in <code>detect_intent_response</code> or the full T2S response in <code>synthesize_response</code>.</p><p>Multiple response messages can be returned in order:</p><p><ul></p><p><li>The first response message for an input utterance contains response from NLU system <code>detect_intent_response</code> with detected intent and N fulfillment messages (N &gt;= 0).</li></p><p><li>The next N response messages contain for each fulfillment message one of the following:</p><p><ul></p><p><li>T2S response <code>synthesize_response</code> with synthesized audio</li></p><p><li>SIP trigger message <code>sip_trigger</code> with SIP trigger extracted from the fulfillment message</li></p><p></ul></p><p></li></p><p></ul></p>
 
         
           <table class="field-table">
@@ -4164,7 +4158,7 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
         
       
         <h3 id="ondewo.csi.SetControlStatusRequest" class="title-badge message">SetControlStatusRequest</h3>
-        <p>Request to set control status</p>
+        <p>Request to set control status.</p>
 
         
           <table class="field-table">
@@ -4188,7 +4182,7 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
         
       
         <h3 id="ondewo.csi.SetControlStatusResponse" class="title-badge message">SetControlStatusResponse</h3>
-        <p>Response of setting the control status with the old and new status objects</p>
+        <p>Response of setting the control status with the old and new status objects.</p>
 
         
           <table class="field-table">
@@ -4219,7 +4213,7 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
         
       
         <h3 id="ondewo.csi.SipTrigger" class="title-badge message">SipTrigger</h3>
-        <p>SIP trigger message</p>
+        <p>SIP trigger message.</p>
 
         
           <table class="field-table">
@@ -4255,7 +4249,7 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
       <div id="ondewo/csi/conversation.proto-enums" class="object-category">Enums</div>
       
         <h3 id="ondewo.csi.ConditionType" class="title-badge enum">ConditionType</h3>
-        <p>Type of condition that need to be satisfied to execute a control message</p>
+        <p>Type of condition that need to be satisfied to execute a control message.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -4271,36 +4265,32 @@ for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. </p></td>
               <tr>
                 <td>immediate</td>
                 <td>1</td>
-                <td><p>Immediate execution of the control message
-Example value need be given as a string in the format: <pre><code>value="5"</code></pre></p></td>
+                <td><p>Immediate execution of the control message. Example value need be given as a string in the format: <pre><code>value=&quot;5&quot;</code></pre></p></td>
               </tr>
             
               <tr>
                 <td>duration</td>
                 <td>2</td>
-                <td><p>Duration in number of seconds after a control message should be executed,
-Example value need be given as a string in the format: <pre><code>value="10"</code></pre></p></td>
+                <td><p>Duration in number of seconds after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;10&quot;</code></pre></p></td>
               </tr>
             
               <tr>
                 <td>datetime</td>
                 <td>3</td>
-                <td><p>Date and time when a control message should be executed,
-Example value need be given as a string in the format: <pre><code>value="2021-12-23T13:45:00.000Z"</code></pre></p></td>
+                <td><p>Date and time when a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;2021-12-23T13:45:00.000Z&quot;</code></pre></p></td>
               </tr>
             
               <tr>
                 <td>interactions</td>
                 <td>4</td>
-                <td><p>Number of interactions of the user with an ONDEWO AI agent after a control message should be executed
-Example value need be given as a string in the format: <pre><code>value="4"</code></pre></p></td>
+                <td><p>Number of interactions of the user with an ONDEWO AI agent after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;4&quot;</code></pre></p></td>
               </tr>
             
           </tbody>
         </table>
       
         <h3 id="ondewo.csi.ControlMessageServiceMethod" class="title-badge enum">ControlMessageServiceMethod</h3>
-        <p>Control message methods to control services during a conversation</p>
+        <p>Control message methods to control services during a conversation.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -4321,25 +4311,25 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_s2t",
-   "method": "update_config",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_s2t&quot;,
+   &quot;method&quot;: &quot;update_config&quot;,
+   &quot;parameters&quot;: [
        {
            // Speech2TextConfig object
-           “s2tPipelineId” : “s2t_pipeline_german_1”,
-           “languageModelName” : “language_model_german”
+           &quot;s2tPipelineId&quot; : &quot;s2t_pipeline_german_1&quot;,
+           &quot;languageModelName&quot; : &quot;language_model_german&quot;
        },
        {
-            // condition_start object => should take effect immediately
-            "type": "immediate",
-            “value”: “0”
+            // condition_start object =&gt; should take effect immediately
+            &quot;type&quot;: &quot;immediate&quot;,
+            &quot;value&quot;: &quot;0&quot;
        },
        {
             // condition_end object - s2t config will be changed back to
             // last valid configuration after 10 interactions of user with
             // the AI agent
-            "type": "interactions",
-	           "value": 10
+            &quot;type&quot;: &quot;interactions&quot;,
+	           &quot;value&quot;: 10
        },
    ]
 }
@@ -4354,16 +4344,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_s2t",
-   "method": "undo_config",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_s2t&quot;,
+   &quot;method&quot;: &quot;undo_config&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
 	          // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4378,16 +4368,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_s2t",
-   "method": "reset_config",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_s2t&quot;,
+   &quot;method&quot;: &quot;reset_config&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4402,16 +4392,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "end_call",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;end_call&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4426,11 +4416,11 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "transfer_call",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;transfer_call&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "transfer_id": "+43123456789@127.0.0.10:5060",
+	 	      &quot;transfer_id&quot;: &quot;+43123456789@127.0.0.10:5060&quot;,
        },
        {
 	 	      // condition_start object
@@ -4438,7 +4428,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4453,14 +4443,14 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "  "play_wav_files",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;play_wav_files&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "wav_files":  [
-               <bytes_of_file_1>,
-               <bytes_of_file_2>,
-               <bytes_of_file_3>,
+	 	      &quot;wav_files&quot;:  [
+               &lt;bytes_of_file_1&gt;,
+               &lt;bytes_of_file_2&gt;,
+               &lt;bytes_of_file_3&gt;,
            ]
        },
        {
@@ -4484,11 +4474,11 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "play_text",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;play_text&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "text": "Welcome from ONDEWO AI Agent! How are you today?",
+	 	      &quot;text&quot;: &quot;Welcome from ONDEWO AI Agent! How are you today?&quot;,
        },
        {
 	 	      // condition_start object
@@ -4496,7 +4486,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4511,16 +4501,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "mute",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;mute&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4535,16 +4525,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_sip",
-   "method": "un_mute",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_sip&quot;,
+   &quot;method&quot;: &quot;un_mute&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4559,8 +4549,8 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "",    <= empty string since it is for all services / no specific service
-   "method": "stop_all_control_messages",
+   &quot;service&quot;: &quot;&quot;,    &lt;= empty string since it is for all services / no specific service
+   &quot;method&quot;: &quot;stop_all_control_messages&quot;,
    "parameters": [
        {
 	 	      // condition_start object
@@ -4583,16 +4573,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "train_agent",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;train_agent&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4607,16 +4597,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "cancel_train_agent",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;cancel_train_agent&quot;,
+   &quot;parameters&quot;: [
        {
 	 	      // condition_start object
        },
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4626,16 +4616,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
               <tr>
                 <td>delete_session</td>
                 <td>13</td>
-                <td><p>NLU: delete session all all session-related information
+                <td><p>NLU: delete session and all session-related information
 
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "delete_session",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;delete_session&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
+	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
        },
        {
 	 	      // condition_start object
@@ -4643,7 +4633,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4658,11 +4648,11 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "delete_all_contexts",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;delete_all_contexts&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
+	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
        },
        {
 	 	      // condition_start object
@@ -4670,7 +4660,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4689,8 +4679,8 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
    "method": "create_context",
    "parameters": [
        {
-	 	      "context": {           <== <NLU Context Object as JSON object>
-               name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e",
+	 	      &quot;context&quot;: {           &lt;== &lt;NLU Context Object as JSON object&gt;
+               &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
                ...,
            }
        },
@@ -4719,8 +4709,8 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
    "method": "update_context",
    "parameters": [
        {
-	 	      "context": {           <== <NLU Context Object as JSON object>
-               name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e",
+	 	      &quot;context&quot;: {           &lt;== &lt;NLU Context Object as JSON object&gt;
+               &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
                ...,
            }
        },
@@ -4745,12 +4735,12 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
 <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
 <pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "delete_context",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;delete_context&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
-	 	      "context_name": "78ea1a20-0784-442b-93c0-eb9e2469420e",
+	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
+	 	      &quot;context_name&quot;: &quot;78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
        },
        {
 	 	      // condition_start object
@@ -4758,7 +4748,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4769,13 +4759,16 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
                 <td>detect_intent</td>
                 <td>18</td>
                 <td><p>NLU: execute a detect intent request based on the provided information in the current session
+
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+<pre><code>
 {
-   "service": "ondewo_nlu",
-   "method": "detect_intent",
-   "parameters": [
+   &quot;service&quot;: &quot;ondewo_nlu&quot;,
+   &quot;method&quot;: &quot;detect_intent&quot;,
+   &quot;parameters&quot;: [
        {
-	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
-	 	      "text": "Are you an artificial intelligence?",
+	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
+	 	      &quot;text&quot;: &quot;Are you an artificial intelligence?&quot;,
        },
        {
 	 	      // condition_start object
@@ -4783,7 +4776,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
        {
 	 	      // condition_end object (OPTIONAL) - for permanent change
            // no condition_end needs to be supplied i.e.
-		      // this parameter is missing or empty “{}”
+		      // this parameter is missing or empty &quot;{}&quot;
        },
    ]
 }
@@ -4794,7 +4787,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
         </table>
       
         <h3 id="ondewo.csi.ControlMessageServiceName" class="title-badge enum">ControlMessageServiceName</h3>
-        <p>Control message services</p>
+        <p>Control message services.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -4853,7 +4846,7 @@ Example value need be given as a string in the format: <pre><code>value="4"</cod
         </table>
       
         <h3 id="ondewo.csi.ControlStatus" class="title-badge enum">ControlStatus</h3>
-        <p>Control status</p>
+        <p>Control status.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -932,7 +932,7 @@ Multiple request messages should be sent in order:
 | ----- | ---- | ----- | ----------- |
 | pipeline_id | [string](#string) |  | Optional. The CSI pipeline ID specified in the initial request. |
 | session_id | [string](#string) |  | <p>Optional. The session or call ID specified in the initial request. It&apos;s up to the API caller to choose an appropriate string. It can be a random number or some type of user identifier (preferably hashed).</p> |
-| audio | [bytes](#bytes) |  |  |
+| audio | [bytes](#bytes) |  | Optional. The input audio content to be recognized. |
 | end_of_stream | [bool](#bool) |  | If <code>true</code>, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for <code>event_type</code> = <code>RECOGNITION_EVENT_TRANSCRIPT</code>. |
 | initial_intent_display_name | [string](#string) |  | Optional. Intent display name to trigger in NLU system in the beginning of the conversation. |
 
@@ -1008,7 +1008,7 @@ SIP trigger message.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | [SipTrigger.SipTriggerType](#ondewo.csi.SipTrigger.SipTriggerType) |  |  |
+| type | [SipTrigger.SipTriggerType](#ondewo.csi.SipTrigger.SipTriggerType) |  | Type of the SIP trigger. |
 | content | [google.protobuf.Struct](#google.protobuf.Struct) |  | extra parameters for the trigger |
 
 
@@ -1132,7 +1132,7 @@ Control status.
 <a name="ondewo.csi.SipTrigger.SipTriggerType"></a>
 
 ### SipTrigger.SipTriggerType
-type of the SIP trigger
+Type of SIP trigger that can be executed during a conversation.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -707,7 +707,7 @@
 <a name="ondewo.csi.CheckUpstreamHealthResponse"></a>
 
 ### CheckUpstreamHealthResponse
-Health checks
+Health checks.
 
 
 | Field | Type | Label | Description |
@@ -724,38 +724,34 @@ Health checks
 <a name="ondewo.csi.Condition"></a>
 
 ### Condition
-A condition message with its type and value
-
+A condition message with its type and value.
 A Condition can be of various types.
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:
+Immediate execution:
 <pre><code>
-immediate execution
 {
-   "type": "immediate"
+   &quot;type&quot;: &quot;immediate&quot;
 }
 </code></pre>
-
-number of interactions of the user with the AI agent
+Number of interactions of the user with the AI agent:
 <pre><code>
 {
-   "type": "interactions",
-   "value": “10”
+   &quot;type&quot;: &quot;interactions&quot;,
+   &quot;value&quot;: &quot;10&quot;
 }
 </code></pre>
-
- number of seconds
+Number of seconds:
 <pre><code>
 {
-   "type": "duration",
-   "value": “3600”
+   &quot;type&quot;: &quot;duration&quot;,
+   &quot;value&quot;: &quot;3600&quot;
 }
 </code></pre>
-
- at a specific date and time
+At a specific date and time:
 <pre><code>
 {
-   "type": "datetime",
-   "value": "2021-12-23T13:45:00.000Z"
+   &quot;type&quot;: &quot;datetime&quot;,
+   &quot;value&quot;: &quot;2021-12-23T13:45:00.000Z&quot;
 }
 </code></pre>
 
@@ -763,7 +759,7 @@ number of interactions of the user with the AI agent
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | type | [ConditionType](#ondewo.csi.ConditionType) |  | Condition type |
-| value | [string](#string) |  | Value of the condition. Examples of conditions values based on the condition type are given in the <pre>ConditionType</pre> documentation |
+| value | [string](#string) |  | Value of the condition. Examples of conditions values based on the condition type are given in the <code>ConditionType</code> documentation. |
 
 
 
@@ -773,19 +769,18 @@ number of interactions of the user with the AI agent
 <a name="ondewo.csi.ControlMessage"></a>
 
 ### ControlMessage
-A control message
-
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+A control message.
+Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:
 <pre><code>
 {
-  "service": "<SERVICE_NAME>", 			// e.g. ondewo_s2t
-  "method": "<SERVICE_CONTROL_METHOD>", 	// e.g. update_config
-  "parameters": [
+  &quot;service&quot;: &quot;&lt;SERVICE_NAME&gt;&quot;, 			// e.g. ondewo_s2t
+  &quot;method&quot;: &quot;&lt;SERVICE_CONTROL_METHOD&gt;&quot;, 	// e.g. update_config
+  &quot;parameters&quot;: [
       // primitive data types and JSON objects are possible
       1,
       1.0,
       -2.0,
-      “string”,
+      &quot;string&quot;,
       true,
   	 {
           // parameter JSON object
@@ -803,7 +798,7 @@ A control message
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| service | [ControlMessageServiceName](#ondewo.csi.ControlMessageServiceName) |  | Service to control. Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' and 'ondewo_csi' |
+| service | [ControlMessageServiceName](#ondewo.csi.ControlMessageServiceName) |  | Service to control. Valid service names are: <code>ondewo_nlu</code>, <code>ondewo_t2s</code>, <code>ondewo_s2t</code>, <code>ondewo_sip</code> and <code>ondewo_csi</code>. |
 | method | [ControlMessageServiceMethod](#ondewo.csi.ControlMessageServiceMethod) |  | Method to invoke on the service |
 | parameters | [ControlMessageServiceParameters](#ondewo.csi.ControlMessageServiceParameters) |  | Parameters to use to invoke the method of the service |
 
@@ -815,7 +810,7 @@ A control message
 <a name="ondewo.csi.ControlMessageServiceParameters"></a>
 
 ### ControlMessageServiceParameters
-Parameters of the control message passed to the service specified in the control message
+Parameters of the control message passed to the service specified in the control message.
 
 
 | Field | Type | Label | Description |
@@ -839,7 +834,7 @@ Parameters of the control message passed to the service specified in the control
 <a name="ondewo.csi.ControlStreamRequest"></a>
 
 ### ControlStreamRequest
-Control stream message
+Control stream message.
 
 
 
@@ -849,7 +844,7 @@ Control stream message
 <a name="ondewo.csi.ControlStreamResponse"></a>
 
 ### ControlStreamResponse
-Control stream response message
+Control stream response message.
 
 
 | Field | Type | Label | Description |
@@ -864,7 +859,7 @@ Control stream response message
 <a name="ondewo.csi.ListS2sPipelinesRequest"></a>
 
 ### ListS2sPipelinesRequest
-The top-level message sent by client to `ListS2sPipelines` endpoint. Currently without arguments.
+The top-level message sent by client to <code>ListS2sPipelines</code> endpoint. Currently without arguments.
 
 TODO: add filtering options
 
@@ -876,7 +871,7 @@ TODO: add filtering options
 <a name="ondewo.csi.ListS2sPipelinesResponse"></a>
 
 ### ListS2sPipelinesResponse
-The top-level message received from `ListS2sPipelines` endpoint.
+The top-level message received from <code>ListS2sPipelines</code> endpoint.
 
 
 | Field | Type | Label | Description |
@@ -891,8 +886,7 @@ The top-level message received from `ListS2sPipelines` endpoint.
 <a name="ondewo.csi.S2sPipeline"></a>
 
 ### S2sPipeline
-The top-level message sent by client to `CreateS2sPipeline` and `UpdateS2sPipeline` endpoints and received from
-`GetS2sPipeline` endpoint.
+The top-level message sent by client to <code>CreateS2sPipeline</code> and <code>UpdateS2sPipeline</code> endpoints and received from <code>GetS2sPipeline</code> endpoint.
 
 
 | Field | Type | Label | Description |
@@ -911,7 +905,7 @@ The top-level message sent by client to `CreateS2sPipeline` and `UpdateS2sPipeli
 <a name="ondewo.csi.S2sPipelineId"></a>
 
 ### S2sPipelineId
-The top-level message sent by client to `GetS2sPipeline` and `DeleteS2sPipeline` endpoints.
+The top-level message sent by client to <code>GetS2sPipeline</code> and <code>DeleteS2sPipeline</code> endpoints.
 
 
 | Field | Type | Label | Description |
@@ -926,23 +920,20 @@ The top-level message sent by client to `GetS2sPipeline` and `DeleteS2sPipeline`
 <a name="ondewo.csi.S2sStreamRequest"></a>
 
 ### S2sStreamRequest
-The top-level message sent by the client to the
-`S2sStream` method.
-
+The top-level message sent by the client to the <code>S2sStream</code> method.
 Multiple request messages should be sent in order:
-
-1.  The first message must contain `pipeline_id` and can contain `session_id` or `initial_intent_display_name`.
-    The message must not contain `audio` nor `end_of_stream`.
-
-2.  All subsequent messages must contain `audio`. If `end_of_stream` is `true`, the stream is closed.
+<ul>
+  <li>The first message must contain <code>pipeline_id</code> and can contain <code>session_id</code> or <code>initial_intent_display_name</code>. The message must not contain <code>audio</code> nor <code>end_of_stream</code>.</li>
+  <li>All subsequent messages must contain <code>audio</code>. If <code>end_of_stream</code> is <code>true</code>, the stream is closed.</li>
+</ul>
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | pipeline_id | [string](#string) |  | Optional. The CSI pipeline ID specified in the initial request. |
-| session_id | [string](#string) |  | Optional. The session or call ID specified in the initial request. It’s up to the API caller to choose an appropriate string. It can be a random number or some type of user identifier (preferably hashed). |
-| audio | [bytes](#bytes) |  | If `true`, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`. |
-| end_of_stream | [bool](#bool) |  |  |
+| session_id | [string](#string) |  | <p>Optional. The session or call ID specified in the initial request. It&apos;s up to the API caller to choose an appropriate string. It can be a random number or some type of user identifier (preferably hashed).</p> |
+| audio | [bytes](#bytes) |  |  |
+| end_of_stream | [bool](#bool) |  | If <code>true</code>, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for <code>event_type</code> = <code>RECOGNITION_EVENT_TRANSCRIPT</code>. |
 | initial_intent_display_name | [string](#string) |  | Optional. Intent display name to trigger in NLU system in the beginning of the conversation. |
 
 
@@ -953,19 +944,18 @@ Multiple request messages should be sent in order:
 <a name="ondewo.csi.S2sStreamResponse"></a>
 
 ### S2sStreamResponse
-The top-level message returned from the
-`S2sStream` method.
-
-A response message is returned for each utterance of the input stream. It contains the full response from NLU system
-in `detect_intent_response` or the full T2S response in `synthesize_response`.
+The top-level message returned from the <code>S2sStream</code> method.
+A response message is returned for each utterance of the input stream. It contains the full response from NLU system in <code>detect_intent_response</code> or the full T2S response in <code>synthesize_response</code>.
 Multiple response messages can be returned in order:
-
-1.  The first response message for an input utterance contains response from NLU system `detect_intent_response`
-    with detected intent and N fulfillment messages (N >= 0).
-
-2.  The next N response messages contain for each fulfillment message one of the following:
-     a. T2S response `synthesize_response` with synthesized audio
-     b. SIP trigger message `sip_trigger` with SIP trigger extracted from the fulfillment message
+<ul>
+  <li>The first response message for an input utterance contains response from NLU system <code>detect_intent_response</code> with detected intent and N fulfillment messages (N &gt;= 0).</li>
+  <li>The next N response messages contain for each fulfillment message one of the following:
+    <ul>
+      <li>T2S response <code>synthesize_response</code> with synthesized audio</li>
+      <li>SIP trigger message <code>sip_trigger</code> with SIP trigger extracted from the fulfillment message</li>
+    </ul>
+  </li>
+</ul>
 
 
 | Field | Type | Label | Description |
@@ -982,7 +972,7 @@ Multiple response messages can be returned in order:
 <a name="ondewo.csi.SetControlStatusRequest"></a>
 
 ### SetControlStatusRequest
-Request to set control status
+Request to set control status.
 
 
 | Field | Type | Label | Description |
@@ -997,7 +987,7 @@ Request to set control status
 <a name="ondewo.csi.SetControlStatusResponse"></a>
 
 ### SetControlStatusResponse
-Response of setting the control status with the old and new status objects
+Response of setting the control status with the old and new status objects.
 
 
 | Field | Type | Label | Description |
@@ -1013,7 +1003,7 @@ Response of setting the control status with the old and new status objects
 <a name="ondewo.csi.SipTrigger"></a>
 
 ### SipTrigger
-SIP trigger message
+SIP trigger message.
 
 
 | Field | Type | Label | Description |
@@ -1031,85 +1021,87 @@ SIP trigger message
 <a name="ondewo.csi.ConditionType"></a>
 
 ### ConditionType
-Type of condition that need to be satisfied to execute a control message
+Type of condition that need to be satisfied to execute a control message.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 | UNKNOWTYPE | 0 | Unknown type |
-| immediate | 1 | Immediate execution of the control message Example value need be given as a string in the format: <pre><code>value="5"</code></pre> |
-| duration | 2 | Duration in number of seconds after a control message should be executed, Example value need be given as a string in the format: <pre><code>value="10"</code></pre> |
-| datetime | 3 | Date and time when a control message should be executed, Example value need be given as a string in the format: <pre><code>value="2021-12-23T13:45:00.000Z"</code></pre> |
-| interactions | 4 | Number of interactions of the user with an ONDEWO AI agent after a control message should be executed Example value need be given as a string in the format: <pre><code>value="4"</code></pre> |
+| immediate | 1 | Immediate execution of the control message. Example value need be given as a string in the format: <pre><code>value=&quot;5&quot;</code></pre> |
+| duration | 2 | Duration in number of seconds after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;10&quot;</code></pre> |
+| datetime | 3 | Date and time when a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;2021-12-23T13:45:00.000Z&quot;</code></pre> |
+| interactions | 4 | Number of interactions of the user with an ONDEWO AI agent after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;4&quot;</code></pre> |
 
 
 
 <a name="ondewo.csi.ControlMessageServiceMethod"></a>
 
 ### ControlMessageServiceMethod
-Control message methods to control services during a conversation
+Control message methods to control services during a conversation.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 | UNKNOWNMETHOD | 0 | Unknown method (default) |
 | update_config | 1 | CSI: update configuration
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_s2t", "method": "update_config", "parameters": [ { // Speech2TextConfig object “s2tPipelineId” : “s2t_pipeline_german_1”, “languageModelName” : “language_model_german” }, { // condition_start object => should take effect immediately "type": "immediate", “value”: “0” }, { // condition_end object - s2t config will be changed back to // last valid configuration after 10 interactions of user with // the AI agent "type": "interactions", 	 "value": 10 }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_s2t&quot;, &quot;method&quot;: &quot;update_config&quot;, &quot;parameters&quot;: [ { // Speech2TextConfig object &quot;s2tPipelineId&quot; : &quot;s2t_pipeline_german_1&quot;, &quot;languageModelName&quot; : &quot;language_model_german&quot; }, { // condition_start object =&gt; should take effect immediately &quot;type&quot;: &quot;immediate&quot;, &quot;value&quot;: &quot;0&quot; }, { // condition_end object - s2t config will be changed back to // last valid configuration after 10 interactions of user with // the AI agent &quot;type&quot;: &quot;interactions&quot;, 	 &quot;value&quot;: 10 }, ] } </code></pre> |
 | undo_config | 2 | CSI: undo previous configuration update
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_s2t", "method": "undo_config", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change 	 // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_s2t&quot;, &quot;method&quot;: &quot;undo_config&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change 	 // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | reset_config | 3 | CSI: reset configuration to default
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_s2t", "method": "reset_config", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_s2t&quot;, &quot;method&quot;: &quot;reset_config&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | end_call | 4 | SIP: end conversation / hang up call
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": "end_call", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;end_call&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | transfer_call | 5 | SIP: transfer call
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": "transfer_call", "parameters": [ { 	 	 "transfer_id": "+43123456789@127.0.0.10:5060", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;transfer_call&quot;, &quot;parameters&quot;: [ { 	 	 &quot;transfer_id&quot;: &quot;+43123456789@127.0.0.10:5060&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | play_wav_files | 6 | SIP: play wav files on the call
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": " "play_wav_files", "parameters": [ { 	 	 "wav_files": [ <bytes_of_file_1>, <bytes_of_file_2>, <bytes_of_file_3>, ] }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;play_wav_files&quot;, &quot;parameters&quot;: [ { 	 	 &quot;wav_files&quot;: [ &lt;bytes_of_file_1&gt;, &lt;bytes_of_file_2&gt;, &lt;bytes_of_file_3&gt;, ] }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
 | play_text | 7 | SIP: play a certain text on the phone based on Text-2-Speech synthesis
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": "play_text", "parameters": [ { 	 	 "text": "Welcome from ONDEWO AI Agent! How are you today?", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;play_text&quot;, &quot;parameters&quot;: [ { 	 	 &quot;text&quot;: &quot;Welcome from ONDEWO AI Agent! How are you today?&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | mute | 8 | SIP: mute microphone
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": "mute", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;mute&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | un_mute | 9 | SIP: unmute microphone
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_sip", "method": "un_mute", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_sip&quot;, &quot;method&quot;: &quot;un_mute&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | stop_all_control_messages | 10 | CSI: stop the execution of all running and scheduled control messages
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "", <= empty string since it is for all services / no specific service "method": "stop_all_control_messages", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;&quot;, &lt;= empty string since it is for all services / no specific service &quot;method&quot;: &quot;stop_all_control_messages&quot;, "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
 | train_agent | 11 | NLU: train agent
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "train_agent", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;train_agent&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | cancel_train_agent | 12 | NLU: cancel the ongoing agent
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "cancel_train_agent", "parameters": [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
-| delete_session | 13 | NLU: delete session all all session-related information
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;cancel_train_agent&quot;, &quot;parameters&quot;: [ { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
+| delete_session | 13 | NLU: delete session and all session-related information
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "delete_session", "parameters": [ { 	 	 "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;delete_session&quot;, &quot;parameters&quot;: [ { 	 	 &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | delete_all_contexts | 14 | NLU: delete all context information in the current session
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "delete_all_contexts", "parameters": [ { 	 	 "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;delete_all_contexts&quot;, &quot;parameters&quot;: [ { 	 	 &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 | create_context | 15 | NLU: create a context based on the provided contextual information in the current session
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "create_context", "parameters": [ { 	 	 "context": { <== <NLU Context Object as JSON object> name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e", ..., } }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "create_context", "parameters": [ { 	 	 &quot;context&quot;: { &lt;== &lt;NLU Context Object as JSON object&gt; &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;, ..., } }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
 | update_context | 16 | NLU: update an existing context based on the provided contextual information in the current session
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "update_context", "parameters": [ { 	 	 "context": { <== <NLU Context Object as JSON object> name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e", ..., } }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "update_context", "parameters": [ { 	 	 &quot;context&quot;: { &lt;== &lt;NLU Context Object as JSON object&gt; &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;, ..., } }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
 | delete_context | 17 | NLU: delete an existing context including all contextual information in the current session
 
-<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { "service": "ondewo_nlu", "method": "delete_context", "parameters": [ { 	 	 "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e", 	 	 "context_name": "78ea1a20-0784-442b-93c0-eb9e2469420e", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
-| detect_intent | 18 | NLU: execute a detect intent request based on the provided information in the current session { "service": "ondewo_nlu", "method": "detect_intent", "parameters": [ { 	 	 "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e", 	 	 "text": "Are you an artificial intelligence?", }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty “{}” }, ] } </code></pre> |
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;delete_context&quot;, &quot;parameters&quot;: [ { 	 	 &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;, 	 	 &quot;context_name&quot;: &quot;78ea1a20-0784-442b-93c0-eb9e2469420e&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
+| detect_intent | 18 | NLU: execute a detect intent request based on the provided information in the current session
+
+<p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p> <pre><code> { &quot;service&quot;: &quot;ondewo_nlu&quot;, &quot;method&quot;: &quot;detect_intent&quot;, &quot;parameters&quot;: [ { 	 	 &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;, 	 	 &quot;text&quot;: &quot;Are you an artificial intelligence?&quot;, }, { 	 	 // condition_start object }, { 	 	 // condition_end object (OPTIONAL) - for permanent change // no condition_end needs to be supplied i.e. 		 // this parameter is missing or empty &quot;{}&quot; }, ] } </code></pre> |
 
 
 
 <a name="ondewo.csi.ControlMessageServiceName"></a>
 
 ### ControlMessageServiceName
-Control message services
+Control message services.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1127,7 +1119,7 @@ Control message services
 <a name="ondewo.csi.ControlStatus"></a>
 
 ### ControlStatus
-Control status
+Control status.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1162,37 +1154,37 @@ type of the SIP trigger
 <a name="ondewo.csi.Conversations"></a>
 
 ### Conversations
-endpoints of csi service
+<p>Endpoints of CSI service.</p>
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateS2sPipeline | [S2sPipeline](#ondewo.csi.S2sPipeline) | [.google.protobuf.Empty](#google.protobuf.Empty) | Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.
+| CreateS2sPipeline | [S2sPipeline](#ondewo.csi.S2sPipeline) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.</p>
 
 <p>Examples:</p>
 
 <pre> grpcurl -plaintext -d '{ "id": "pizza", "s2t_pipeline_id": "default_german", "nlu_project_id": "1f3425d2-41fd-4970-87e6-88e8e121bb49", "nlu_language_code": "de", "t2s_pipeline_id": "default_german" }' localhost:50051 ondewo.csi.Conversations.CreateS2sPipeline </pre> <samp>{}</samp> |
-| GetS2sPipeline | [S2sPipelineId](#ondewo.csi.S2sPipelineId) | [S2sPipeline](#ondewo.csi.S2sPipeline) | Retrieve the S2S pipeline with the ID specified in the request message.
+| GetS2sPipeline | [S2sPipelineId](#ondewo.csi.S2sPipelineId) | [S2sPipeline](#ondewo.csi.S2sPipeline) | <p>Retrieve the S2S pipeline with the ID specified in the request message.</p>
 
 <p>Examples:</p>
 
 <pre> grpcurl -plaintext -d '{"id": "pizza"}' localhost:50051 ondewo.csi.Conversations.GetS2sPipeline </pre> <samp>{ "id": "pizza", "s2t_pipeline_id": "default_german", "nlu_project_id": "1f3425d2-41fd-4970-87e6-88e8e121bb49", "nlu_language_code": "de", "t2s_pipeline_id": "default_german" } </samp> |
-| UpdateS2sPipeline | [S2sPipeline](#ondewo.csi.S2sPipeline) | [.google.protobuf.Empty](#google.protobuf.Empty) | Update the S2S pipeline specified in the request message. The pipeline must exist.
+| UpdateS2sPipeline | [S2sPipeline](#ondewo.csi.S2sPipeline) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Update the S2S pipeline specified in the request message. The pipeline must exist.</p>
 
 <p>Examples:</p>
 
 <pre> grpcurl -plaintext -d '{ "id": "pizza", "s2t_pipeline_id": "default_german", "nlu_project_id": "1f3425d2-41fd-4970-87e6-88e8e121bb49", "nlu_language_code": "en", "t2s_pipeline_id": "default_german" }' localhost:50051 ondewo.csi.Conversations.UpdateS2sPipeline </pre> <samp>{}</samp> |
-| DeleteS2sPipeline | [S2sPipelineId](#ondewo.csi.S2sPipelineId) | [.google.protobuf.Empty](#google.protobuf.Empty) | Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.
+| DeleteS2sPipeline | [S2sPipelineId](#ondewo.csi.S2sPipelineId) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.</p>
 
 <p>Examples:</p>
 
 <pre> grpcurl -plaintext -d '{"id": "pizza"}' localhost:50051 ondewo.csi.Conversations.DeleteS2sPipeline </pre> <samp>{}</samp> |
-| ListS2sPipelines | [ListS2sPipelinesRequest](#ondewo.csi.ListS2sPipelinesRequest) | [ListS2sPipelinesResponse](#ondewo.csi.ListS2sPipelinesResponse) | List all S2S pipelines of the server.
+| ListS2sPipelines | [ListS2sPipelinesRequest](#ondewo.csi.ListS2sPipelinesRequest) | [ListS2sPipelinesResponse](#ondewo.csi.ListS2sPipelinesResponse) | <p>List all S2S pipelines of the server.</p>
 
 <p>Examples:</p>
 
 <pre> grpcurl -plaintext localhost:50051 ondewo.csi.Conversations.ListS2sPipelines </pre> <samp>{ "pipelines": [ { "id": "pizza", "s2t_pipeline_id": "default_german", "nlu_project_id": "1f3425d2-41fd-4970-87e6-88e8e121bb49", "nlu_language_code": "de", "t2s_pipeline_id": "default_german" } ] }</samp> |
-| S2sStream | [S2sStreamRequest](#ondewo.csi.S2sStreamRequest) stream | [S2sStreamResponse](#ondewo.csi.S2sStreamResponse) stream | Processes a natural language query in audio format in a streaming fashion and returns structured, actionable data as a result. |
-| CheckUpstreamHealth | [.google.protobuf.Empty](#google.protobuf.Empty) | [CheckUpstreamHealthResponse](#ondewo.csi.CheckUpstreamHealthResponse) | Check the health of S2T, NLU and T2S servers
+| S2sStream | [S2sStreamRequest](#ondewo.csi.S2sStreamRequest) stream | [S2sStreamResponse](#ondewo.csi.S2sStreamResponse) stream | <p>Processes a natural language query in audio format in a streaming fashion and returns structured, actionable data as a result.</p> |
+| CheckUpstreamHealth | [.google.protobuf.Empty](#google.protobuf.Empty) | [CheckUpstreamHealthResponse](#ondewo.csi.CheckUpstreamHealthResponse) | <p>Check the health of S2T, NLU and T2S servers.</p>
 
 <p>Examples:</p>
 
@@ -1201,8 +1193,8 @@ endpoints of csi service
 All upstreams healthy: <samp>{}</samp>
 
 All upstreams unhealthy: <samp>{ "s2t_status": { "code": 14, "message": "failed to connect to all addresses" }, "nlu_status": { "code": 14, "message": "failed to connect to all addresses" }, "t2s_status": { "code": 14, "message": "failed to connect to all addresses" } }</samp> |
-| GetControlStream | [ControlStreamRequest](#ondewo.csi.ControlStreamRequest) | [ControlStreamResponse](#ondewo.csi.ControlStreamResponse) stream | Get the control stream to control sip, t2s, s2t etc. during a conversation |
-| SetControlStatus | [SetControlStatusRequest](#ondewo.csi.SetControlStatusRequest) | [SetControlStatusResponse](#ondewo.csi.SetControlStatusResponse) | Send a message on the control stream to control sip, t2s, s2t etc. during a conversation |
+| GetControlStream | [ControlStreamRequest](#ondewo.csi.ControlStreamRequest) | [ControlStreamResponse](#ondewo.csi.ControlStreamResponse) stream | <p>Get the control stream to control sip, t2s, s2t etc. during a conversation.</p> |
+| SetControlStatus | [SetControlStatusRequest](#ondewo.csi.SetControlStatusRequest) | [SetControlStatusResponse](#ondewo.csi.SetControlStatusResponse) | <p>Send a message on the control stream to control sip, t2s, s2t etc. during a conversation.</p> |
 
  <!-- end services -->
 

--- a/ondewo/csi/conversation.proto
+++ b/ondewo/csi/conversation.proto
@@ -25,9 +25,9 @@ import "ondewo/s2t/speech-to-text.proto";
 import "ondewo/nlu/context.proto";
 import "google/protobuf/any.proto";
 
-// endpoints of csi service
+// <p>Endpoints of CSI service.</p>
 service Conversations {
-    // Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.
+    // <p>Create the S2S pipeline specified in the request message. The pipeline with the specified ID must not exist.</p>
     //
     // <p>Examples:</p>
     //
@@ -43,7 +43,7 @@ service Conversations {
     // <samp>{}</samp>
     rpc CreateS2sPipeline (S2sPipeline) returns (google.protobuf.Empty) {};
 
-    // Retrieve the S2S pipeline with the ID specified in the request message.
+    // <p>Retrieve the S2S pipeline with the ID specified in the request message.</p>
     //
     // <p>Examples:</p>
     //
@@ -60,7 +60,7 @@ service Conversations {
     // </samp>
     rpc GetS2sPipeline (S2sPipelineId) returns (S2sPipeline) {};
 
-    // Update the S2S pipeline specified in the request message. The pipeline must exist.
+    // <p>Update the S2S pipeline specified in the request message. The pipeline must exist.</p>
     //
     // <p>Examples:</p>
     //
@@ -76,7 +76,7 @@ service Conversations {
     // <samp>{}</samp>
     rpc UpdateS2sPipeline (S2sPipeline) returns (google.protobuf.Empty) {};
 
-    // Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.
+    // <p>Delete the S2S pipeline with the ID specified in the request message. The pipeline must exist.</p>
     //
     // <p>Examples:</p>
     //
@@ -86,7 +86,7 @@ service Conversations {
     // <samp>{}</samp>
     rpc DeleteS2sPipeline (S2sPipelineId) returns (google.protobuf.Empty) {};
 
-    // List all S2S pipelines of the server.
+    // <p>List all S2S pipelines of the server.</p>
     //
     // <p>Examples:</p>
     //
@@ -106,11 +106,10 @@ service Conversations {
     // }</samp>
     rpc ListS2sPipelines (ListS2sPipelinesRequest) returns (ListS2sPipelinesResponse) {};
 
-    // Processes a natural language query in audio format in a streaming fashion
-    // and returns structured, actionable data as a result.
+    // <p>Processes a natural language query in audio format in a streaming fashion and returns structured, actionable data as a result.</p>
     rpc S2sStream (stream S2sStreamRequest) returns (stream S2sStreamResponse) {};
 
-    // Check the health of S2T, NLU and T2S servers
+    // <p>Check the health of S2T, NLU and T2S servers.</p>
     //
     // <p>Examples:</p>
     //
@@ -138,16 +137,15 @@ service Conversations {
     // }</samp>
     rpc CheckUpstreamHealth(google.protobuf.Empty) returns (CheckUpstreamHealthResponse) {};
 
-    // Get the control stream to control sip, t2s, s2t etc. during a conversation
+    // <p>Get the control stream to control sip, t2s, s2t etc. during a conversation.</p>
     rpc GetControlStream (ControlStreamRequest) returns (stream ControlStreamResponse) {};
 
-    // Send a message on the control stream to control sip, t2s, s2t etc. during a conversation
+    // <p>Send a message on the control stream to control sip, t2s, s2t etc. during a conversation.</p>
     rpc SetControlStatus (SetControlStatusRequest) returns (SetControlStatusResponse) {};
 
 }
 
-// The top-level message sent by client to `CreateS2sPipeline` and `UpdateS2sPipeline` endpoints and received from
-// `GetS2sPipeline` endpoint.
+// The top-level message sent by client to <code>CreateS2sPipeline</code> and <code>UpdateS2sPipeline</code> endpoints and received from <code>GetS2sPipeline</code> endpoint.
 message S2sPipeline {
 
     // Required. CSI pipeline identifier consisting of S2T, NLU and T2S configuration. ID can be any non-empty string.
@@ -167,7 +165,7 @@ message S2sPipeline {
 
 }
 
-// The top-level message sent by client to `GetS2sPipeline` and `DeleteS2sPipeline` endpoints.
+// The top-level message sent by client to <code>GetS2sPipeline</code> and <code>DeleteS2sPipeline</code> endpoints.
 message S2sPipelineId {
 
     // Required. CSI pipeline identifier.
@@ -175,12 +173,12 @@ message S2sPipelineId {
 
 }
 
-// The top-level message sent by client to `ListS2sPipelines` endpoint. Currently without arguments.
+// The top-level message sent by client to <code>ListS2sPipelines</code> endpoint. Currently without arguments.
 message ListS2sPipelinesRequest {
     // TODO: add filtering options
 }
 
-// The top-level message received from `ListS2sPipelines` endpoint.
+// The top-level message received from <code>ListS2sPipelines</code> endpoint.
 message ListS2sPipelinesResponse {
 
     // Collection of S2S pipelines of the server.
@@ -188,31 +186,24 @@ message ListS2sPipelinesResponse {
 
 }
 
-// The top-level message sent by the client to the
-// `S2sStream` method.
-//
+// The top-level message sent by the client to the <code>S2sStream</code> method.
 // Multiple request messages should be sent in order:
-//
-// 1.  The first message must contain `pipeline_id` and can contain `session_id` or `initial_intent_display_name`.
-//     The message must not contain `audio` nor `end_of_stream`.
-//
-// 2.  All subsequent messages must contain `audio`. If `end_of_stream` is `true`, the stream is closed.
+// <ul>
+//   <li>The first message must contain <code>pipeline_id</code> and can contain <code>session_id</code> or <code>initial_intent_display_name</code>. The message must not contain <code>audio</code> nor <code>end_of_stream</code>.</li>
+//   <li>All subsequent messages must contain <code>audio</code>. If <code>end_of_stream</code> is <code>true</code>, the stream is closed.</li>
+// </ul>
 message S2sStreamRequest {
 
     // Optional. The CSI pipeline ID specified in the initial request.
     string pipeline_id = 1;
 
-    // Optional. The session or call ID specified in the initial request. It’s up to the API caller to choose
-    // an appropriate string. It can be a random number or some type of user identifier (preferably hashed).
+    // <p>Optional. The session or call ID specified in the initial request. It&apos;s up to the API caller to choose an appropriate string. It can be a random number or some type of user identifier (preferably hashed).</p>
     string session_id = 2;
 
     // Optional. The input audio content to be recognized.
 
     bytes audio = 3;
-    // If `true`, the recognizer will not return
-    // any further hypotheses about this piece of the audio. May only be populated
-    // for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`.
-
+    // If <code>true</code>, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for <code>event_type</code> = <code>RECOGNITION_EVENT_TRANSCRIPT</code>.
     bool end_of_stream = 4;
 
     // Optional. Intent display name to trigger in NLU system in the beginning of the conversation.
@@ -220,19 +211,18 @@ message S2sStreamRequest {
 
 }
 
-// The top-level message returned from the
-// `S2sStream` method.
-//
-// A response message is returned for each utterance of the input stream. It contains the full response from NLU system
-// in `detect_intent_response` or the full T2S response in `synthesize_response`.
+// The top-level message returned from the <code>S2sStream</code> method.
+// A response message is returned for each utterance of the input stream. It contains the full response from NLU system in <code>detect_intent_response</code> or the full T2S response in <code>synthesize_response</code>.
 // Multiple response messages can be returned in order:
-//
-// 1.  The first response message for an input utterance contains response from NLU system `detect_intent_response`
-//     with detected intent and N fulfillment messages (N >= 0).
-//
-// 2.  The next N response messages contain for each fulfillment message one of the following:
-//      a. T2S response `synthesize_response` with synthesized audio
-//      b. SIP trigger message `sip_trigger` with SIP trigger extracted from the fulfillment message
+// <ul>
+//   <li>The first response message for an input utterance contains response from NLU system <code>detect_intent_response</code> with detected intent and N fulfillment messages (N &gt;= 0).</li>
+//   <li>The next N response messages contain for each fulfillment message one of the following:
+//     <ul>
+//       <li>T2S response <code>synthesize_response</code> with synthesized audio</li>
+//       <li>SIP trigger message <code>sip_trigger</code> with SIP trigger extracted from the fulfillment message</li>
+//     </ul>
+//   </li>
+// </ul>
 message S2sStreamResponse {
 
     oneof response {
@@ -249,7 +239,7 @@ message S2sStreamResponse {
 
 }
 
-// SIP trigger message
+// SIP trigger message.
 message SipTrigger {
 
     // type of the SIP trigger
@@ -288,7 +278,7 @@ message SipTrigger {
 
 }
 
-// Health checks
+// Health checks.
 message CheckUpstreamHealthResponse {
 
     // Health checks for Speech-2-Text
@@ -302,10 +292,10 @@ message CheckUpstreamHealthResponse {
 
 }
 
-// Control stream message
+// Control stream message.
 message ControlStreamRequest{}
 
-// Control status
+// Control status.
 enum ControlStatus {
 
     // Status that control stream is ok
@@ -319,7 +309,7 @@ enum ControlStatus {
 
 }
 
-// Control stream response message
+// Control stream response message.
 message ControlStreamResponse{
 
     // Control status
@@ -327,7 +317,7 @@ message ControlStreamResponse{
 
 }
 
-// Request to set control status
+// Request to set control status.
 message SetControlStatusRequest{
 
     // Control status
@@ -335,7 +325,7 @@ message SetControlStatusRequest{
 
 }
 
-// Response of setting the control status with the old and new status objects
+// Response of setting the control status with the old and new status objects.
 message SetControlStatusResponse{
 
     // Previous 'old' control status
@@ -346,7 +336,7 @@ message SetControlStatusResponse{
 
 }
 
-// Control message services
+// Control message services.
 enum ControlMessageServiceName {
 
     // Unknown control message service name
@@ -374,7 +364,7 @@ enum ControlMessageServiceName {
     ondewo_survey = 7;
 }
 
-// Control message methods to control services during a conversation
+// Control message methods to control services during a conversation.
 enum ControlMessageServiceMethod {
 
     // Unknown method (default)
@@ -385,25 +375,25 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_s2t",
-    //    "method": "update_config",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_s2t&quot;,
+    //    &quot;method&quot;: &quot;update_config&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //            // Speech2TextConfig object
-    //            “s2tPipelineId” : “s2t_pipeline_german_1”,
-    //            “languageModelName” : “language_model_german”
+    //            &quot;s2tPipelineId&quot; : &quot;s2t_pipeline_german_1&quot;,
+    //            &quot;languageModelName&quot; : &quot;language_model_german&quot;
     //        },
     //        {
-    //             // condition_start object => should take effect immediately
-    //             "type": "immediate",
-    //             “value”: “0”
+    //             // condition_start object =&gt; should take effect immediately
+    //             &quot;type&quot;: &quot;immediate&quot;,
+    //             &quot;value&quot;: &quot;0&quot;
     //        },
     //        {
     //             // condition_end object - s2t config will be changed back to
     //             // last valid configuration after 10 interactions of user with
     //             // the AI agent
-    //             "type": "interactions",
-    //	           "value": 10
+    //             &quot;type&quot;: &quot;interactions&quot;,
+    //	           &quot;value&quot;: 10
     //        },
     //    ]
     //}
@@ -415,16 +405,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_s2t",
-    //    "method": "undo_config",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_s2t&quot;,
+    //    &quot;method&quot;: &quot;undo_config&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //	          // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -436,16 +426,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_s2t",
-    //    "method": "reset_config",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_s2t&quot;,
+    //    &quot;method&quot;: &quot;reset_config&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -457,16 +447,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "end_call",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;end_call&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -478,11 +468,11 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "transfer_call",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;transfer_call&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "transfer_id": "+43123456789@127.0.0.10:5060",
+    //	 	      &quot;transfer_id&quot;: &quot;+43123456789@127.0.0.10:5060&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -490,7 +480,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -502,14 +492,14 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "  "play_wav_files",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;play_wav_files&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "wav_files":  [
-    //                <bytes_of_file_1>,
-    //                <bytes_of_file_2>,
-    //                <bytes_of_file_3>,
+    //	 	      &quot;wav_files&quot;:  [
+    //                &lt;bytes_of_file_1&gt;,
+    //                &lt;bytes_of_file_2&gt;,
+    //                &lt;bytes_of_file_3&gt;,
     //            ]
     //        },
     //        {
@@ -530,11 +520,11 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "play_text",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;play_text&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "text": "Welcome from ONDEWO AI Agent! How are you today?",
+    //	 	      &quot;text&quot;: &quot;Welcome from ONDEWO AI Agent! How are you today?&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -542,7 +532,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -554,16 +544,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "mute",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;mute&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -575,16 +565,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_sip",
-    //    "method": "un_mute",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_sip&quot;,
+    //    &quot;method&quot;: &quot;un_mute&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -596,8 +586,8 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "",    <= empty string since it is for all services / no specific service
-    //    "method": "stop_all_control_messages",
+    //    &quot;service&quot;: &quot;&quot;,    &lt;= empty string since it is for all services / no specific service
+    //    &quot;method&quot;: &quot;stop_all_control_messages&quot;,
     //    "parameters": [
     //        {
     //	 	      // condition_start object
@@ -617,16 +607,16 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "train_agent",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;train_agent&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -638,32 +628,32 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "cancel_train_agent",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;cancel_train_agent&quot;,
+    //    &quot;parameters&quot;: [
     //        {
     //	 	      // condition_start object
     //        },
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
     //</code></pre>
     cancel_train_agent = 12;
 
-    // NLU: delete session all all session-related information
+    // NLU: delete session and all session-related information
     //
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "delete_session",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;delete_session&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
+    //	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -671,7 +661,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -683,11 +673,11 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "delete_all_contexts",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;delete_all_contexts&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
+    //	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -695,7 +685,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -711,8 +701,8 @@ enum ControlMessageServiceMethod {
     //    "method": "create_context",
     //    "parameters": [
     //        {
-    //	 	      "context": {           <== <NLU Context Object as JSON object>
-    //                name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e",
+    //	 	      &quot;context&quot;: {           &lt;== &lt;NLU Context Object as JSON object&gt;
+    //                &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/ss2ea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
     //                ...,
     //            }
     //        },
@@ -738,8 +728,8 @@ enum ControlMessageServiceMethod {
     //    "method": "update_context",
     //    "parameters": [
     //        {
-    //	 	      "context": {           <== <NLU Context Object as JSON object>
-    //                name": "projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e",
+    //	 	      &quot;context&quot;: {           &lt;== &lt;NLU Context Object as JSON object&gt;
+    //                &quot;name&quot;: &quot;projects/db46dcf8-2d2c-4115-ac38-eff443ea0e72/agent/sessions/2dea1a20-0784-442b-93c0-eb9e2469420e/contexts/78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
     //                ...,
     //            }
     //        },
@@ -761,12 +751,12 @@ enum ControlMessageServiceMethod {
     // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
     // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "delete_context",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;delete_context&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
-    //	 	      "context_name": "78ea1a20-0784-442b-93c0-eb9e2469420e",
+    //	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
+    //	 	      &quot;context_name&quot;: &quot;78ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -774,7 +764,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -782,13 +772,16 @@ enum ControlMessageServiceMethod {
     delete_context = 17;
 
     // NLU: execute a detect intent request based on the provided information in the current session
+    //
+    // <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+    // <pre><code>
     //{
-    //    "service": "ondewo_nlu",
-    //    "method": "detect_intent",
-    //    "parameters": [
+    //    &quot;service&quot;: &quot;ondewo_nlu&quot;,
+    //    &quot;method&quot;: &quot;detect_intent&quot;,
+    //    &quot;parameters&quot;: [
     //        {
-    //	 	      "session_id": "97ea1a20-0784-442b-93c0-eb9e2469420e",
-    //	 	      "text": "Are you an artificial intelligence?",
+    //	 	      &quot;session_id&quot;: &quot;97ea1a20-0784-442b-93c0-eb9e2469420e&quot;,
+    //	 	      &quot;text&quot;: &quot;Are you an artificial intelligence?&quot;,
     //        },
     //        {
     //	 	      // condition_start object
@@ -796,7 +789,7 @@ enum ControlMessageServiceMethod {
     //        {
     //	 	      // condition_end object (OPTIONAL) - for permanent change
     //            // no condition_end needs to be supplied i.e.
-    //		      // this parameter is missing or empty “{}”
+    //		      // this parameter is missing or empty &quot;{}&quot;
     //        },
     //    ]
     //}
@@ -805,62 +798,54 @@ enum ControlMessageServiceMethod {
 
 }
 
-// Type of condition that need to be satisfied to execute a control message
+// Type of condition that need to be satisfied to execute a control message.
 enum ConditionType {
 
     // Unknown type
     UNKNOWTYPE = 0;
 
-    // Immediate execution of the control message
-    // Example value need be given as a string in the format: <pre><code>value="5"</code></pre>
+    // Immediate execution of the control message. Example value need be given as a string in the format: <pre><code>value=&quot;5&quot;</code></pre>
     immediate = 1;
 
-    // Duration in number of seconds after a control message should be executed,
-    // Example value need be given as a string in the format: <pre><code>value="10"</code></pre>
+    // Duration in number of seconds after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;10&quot;</code></pre>
     duration = 2;
 
-    // Date and time when a control message should be executed,
-    // Example value need be given as a string in the format: <pre><code>value="2021-12-23T13:45:00.000Z"</code></pre>
+    // Date and time when a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;2021-12-23T13:45:00.000Z&quot;</code></pre>
     datetime = 3;
 
-    // Number of interactions of the user with an ONDEWO AI agent after a control message should be executed
-    // Example value need be given as a string in the format: <pre><code>value="4"</code></pre>
+    // Number of interactions of the user with an ONDEWO AI agent after a control message should be executed. Example value need be given as a string in the format: <pre><code>value=&quot;4&quot;</code></pre>
     interactions = 4;
 
 }
 
-// A condition message with its type and value
-//
+// A condition message with its type and value.
 // A Condition can be of various types.
-// <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+// Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:
+// Immediate execution:
 // <pre><code>
-// immediate execution
 //{
-//    "type": "immediate"
+//    &quot;type&quot;: &quot;immediate&quot;
 //}
 //</code></pre>
-//
-// number of interactions of the user with the AI agent
+// Number of interactions of the user with the AI agent:
 // <pre><code>
 //{
-//    "type": "interactions",
-//    "value": “10”
+//    &quot;type&quot;: &quot;interactions&quot;,
+//    &quot;value&quot;: &quot;10&quot;
 //}
 //</code></pre>
-//
-//  number of seconds
+// Number of seconds:
 // <pre><code>
 //{
-//    "type": "duration",
-//    "value": “3600”
+//    &quot;type&quot;: &quot;duration&quot;,
+//    &quot;value&quot;: &quot;3600&quot;
 //}
 //</code></pre>
-//
-//  at a specific date and time
+// At a specific date and time:
 // <pre><code>
 //{
-//    "type": "datetime",
-//    "value": "2021-12-23T13:45:00.000Z"
+//    &quot;type&quot;: &quot;datetime&quot;,
+//    &quot;value&quot;: &quot;2021-12-23T13:45:00.000Z&quot;
 //}
 //</code></pre>
 message Condition{
@@ -868,13 +853,12 @@ message Condition{
     // Condition type
     ConditionType type = 1;
 
-    // Value of the condition.
-    // Examples of conditions values based on the condition type are given in the <pre>ConditionType</pre> documentation
+    // Value of the condition. Examples of conditions values based on the condition type are given in the <code>ConditionType</code> documentation.
     string value = 2;
 
 }
 
-// Parameters of the control message passed to the service specified in the control message
+// Parameters of the control message passed to the service specified in the control message.
 message ControlMessageServiceParameters {
 
     // Configuration
@@ -914,19 +898,18 @@ message ControlMessageServiceParameters {
 
 }
 
-// A control message
-//
-// <p>Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:</p>
+// A control message.
+// Example of a JSON how to invoke a control message via ONDEWO RABBITMQ service:
 // <pre><code>
 //{
-//   "service": "<SERVICE_NAME>", 			// e.g. ondewo_s2t
-//   "method": "<SERVICE_CONTROL_METHOD>", 	// e.g. update_config
-//   "parameters": [
+//   &quot;service&quot;: &quot;&lt;SERVICE_NAME&gt;&quot;, 			// e.g. ondewo_s2t
+//   &quot;method&quot;: &quot;&lt;SERVICE_CONTROL_METHOD&gt;&quot;, 	// e.g. update_config
+//   &quot;parameters&quot;: [
 //       // primitive data types and JSON objects are possible
 //       1,
 //       1.0,
 //       -2.0,
-//       “string”,
+//       &quot;string&quot;,
 //       true,
 //   	 {
 //           // parameter JSON object
@@ -942,8 +925,7 @@ message ControlMessageServiceParameters {
 //</code></pre>
 message ControlMessage {
 
-    // Service to control.
-    // Valid service names are:'ondewo_nlu', 'ondewo_t2s', 'ondewo_s2t', 'ondewo_sip' and 'ondewo_csi'
+    // Service to control. Valid service names are: <code>ondewo_nlu</code>, <code>ondewo_t2s</code>, <code>ondewo_s2t</code>, <code>ondewo_sip</code> and <code>ondewo_csi</code>.
     ControlMessageServiceName service = 1;
 
     // Method to invoke on the service

--- a/ondewo/csi/conversation.proto
+++ b/ondewo/csi/conversation.proto
@@ -201,7 +201,6 @@ message S2sStreamRequest {
     string session_id = 2;
 
     // Optional. The input audio content to be recognized.
-
     bytes audio = 3;
     // If <code>true</code>, the recognizer will not return any further hypotheses about this piece of the audio. May only be populated for <code>event_type</code> = <code>RECOGNITION_EVENT_TRANSCRIPT</code>.
     bool end_of_stream = 4;
@@ -225,6 +224,7 @@ message S2sStreamRequest {
 // </ul>
 message S2sStreamResponse {
 
+    // Response type for the S2S stream. One of the following will be populated.
     oneof response {
 
         // full NLU detect intent response
@@ -242,7 +242,7 @@ message S2sStreamResponse {
 // SIP trigger message.
 message SipTrigger {
 
-    // type of the SIP trigger
+    // Type of SIP trigger that can be executed during a conversation.
     enum SipTriggerType {
 
         // should never be used
@@ -271,6 +271,7 @@ message SipTrigger {
 
     }
 
+    // Type of the SIP trigger.
     SipTriggerType type = 1;
 
     // extra parameters for the trigger


### PR DESCRIPTION
### This PR improves documentation generation and consistency across proto files by:

Adding dedicated documentation build targets to the **Makefile** to simplify and standardise the docs build process.

Updating all comments in `conversation.proto` to use valid HTML formatting instead of Markdown, ensuring correct rendering in HTML-based proto documentation tools.